### PR TITLE
Issues 63

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/Footnote.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/Footnote.hs
@@ -86,7 +86,7 @@ footnoteBlockSpec = BlockSpec
      , blockConstructor    = \node ->
           mconcat <$> mapM (\n ->
               blockConstructor (blockSpec (rootLabel n)) n)
-            (reverse (subForest node))
+           (subForest (reverseSubforests node))
      , blockFinalize       = \(Node root children) parent -> do
          let (num, lab') = fromDyn (blockData root) (1, mempty)
          st <- getState

--- a/commonmark-extensions/test/footnotes.md
+++ b/commonmark-extensions/test/footnotes.md
@@ -87,4 +87,48 @@ Hi!
 </section>
 ````````````````````````````````
 
+Issue #63 - Nested blocks in footnotes are rendered in reverse order
+```````````````````````````````` example
+Hello[^test]
 
+Footnote containing a list[^list]
+
+[^test]:
+    > first
+    >
+    > second
+    >
+    > third
+
+[^list]:
+    1. First element
+    1. Second element
+.
+<p>Hello<sup class="footnote-ref"><a href="#fn-test" id="fnref-test">1</a></sup></p>
+<p>Footnote containing a list<sup class="footnote-ref"><a href="#fn-list" id="fnref-list">2</a></sup></p>
+<section class="footnotes">
+<div class="footnote" id="fn-test">
+<div class="footnote-number">
+<a href="#fnref-test">1</a>
+</div>
+<div class="footnote-contents">
+<blockquote>
+<p>first</p>
+<p>second</p>
+<p>third</p>
+</blockquote>
+</div>
+</div>
+<div class="footnote" id="fn-list">
+<div class="footnote-number">
+<a href="#fnref-list">2</a>
+</div>
+<div class="footnote-contents">
+<ol>
+<li>First element</li>
+<li>Second element</li>
+</ol>
+</div>
+</div>
+</section>
+````````````````````````````````

--- a/commonmark/src/Commonmark/Blocks.hs
+++ b/commonmark/src/Commonmark/Blocks.hs
@@ -30,6 +30,7 @@ module Commonmark.Blocks
   , interruptsParagraph
   , linkReferenceDef
   , renderChildren
+  , reverseSubforests
   -- * BlockSpecs
   , docSpec
   , indentedCodeSpec


### PR DESCRIPTION
Since the BlockNode in a footnote are not stored in `nodeStack` they won't have `reverseSubforests` applied to correct the inverse order that results from the stack based parsing.
