### PR TITLE
Update lower version bounds

### DIFF
--- a/commonmark-extensions/commonmark-extensions.cabal
+++ b/commonmark-extensions/commonmark-extensions.cabal
@@ -59,7 +59,7 @@ library
     , transformers
     , filepath
     , network-uri
-    , commonmark >= 0.2 && < 0.3
+    , commonmark >= 0.2.2 && < 0.3
     -- for extensions:
     , emojis >= 0.1 && < 0.2
   exposed-modules:


### PR DESCRIPTION
This prevents a build failure when 0.2.1 of `commonmark` is selected, because `commonmark-extensions` relies on an export that was added in 0.2.2.

Fixes #93