### PR TITLE
Add intermediate representation

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/Emoji.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/Emoji.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
 module Commonmark.Extensions.Emoji
   ( HasEmoji(..)
   , emojiSpec )
@@ -11,9 +14,11 @@ import Commonmark.Inlines
 import Commonmark.SourceMap
 import Commonmark.TokParsers
 import Commonmark.Html
+import Commonmark.Nodes
 import Text.Emoji (emojiFromAlias)
 import Text.Parsec
 import Data.Text (Text)
+import Data.Typeable (Typeable)
 
 emojiSpec :: (Monad m, IsBlock il bl, IsInline il, HasEmoji il)
           => SyntaxSpec m il bl
@@ -46,3 +51,19 @@ parseEmoji = try $ do
   case emojiFromAlias kw of
     Nothing -> fail "emoji not found"
     Just t  -> return $! emoji kw t
+
+data NodeTypeEmoji a
+  = NodeEmoji Text Text
+  deriving (Show)
+
+instance Typeable a => NodeType NodeTypeEmoji a where
+  type FromNodeType NodeTypeEmoji a = HasEmoji a
+  fromNodeType = \case
+    NodeEmoji kw t -> emoji kw t
+
+instance ToPlainText (NodeTypeEmoji a) where
+  toPlainText = \case
+    NodeEmoji kw _ -> ":" <> kw <> ":"
+
+instance (Typeable a, HasEmoji a) => HasEmoji (Nodes a) where
+  emoji kw t = singleNode $ NodeEmoji kw t

--- a/commonmark-extensions/src/Commonmark/Extensions/Footnote.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/Footnote.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
 module Commonmark.Extensions.Footnote
   ( footnoteSpec
   , HasFootnote(..)
@@ -18,6 +20,7 @@ import Commonmark.Inlines
 import Commonmark.SourceMap
 import Commonmark.TokParsers
 import Commonmark.ReferenceMap
+import Commonmark.Nodes hiding (Node (..))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad (mzero)
 import Data.List
@@ -169,3 +172,27 @@ instance (HasFootnote il bl, Semigroup bl, Semigroup il)
   footnote num lab' x = (footnote num lab' <$> x) <* addName "footnote"
   footnoteList items = footnoteList <$> sequence items
   footnoteRef x y z = (footnoteRef x y <$> z) <* addName "footnoteRef"
+
+data NodeTypeFootnote a
+  = NodeFootnote Int Text (Nodes a)
+  | NodeFootnoteList [Nodes a]
+  | NodeFootnoteRef Text Text (Nodes a)
+  deriving (Show)
+
+instance Typeable a => NodeType NodeTypeFootnote a where
+  type FromNodeType NodeTypeFootnote a = HasFootnote a a
+  fromNodeType = \case
+    NodeFootnote num lab x -> footnote num lab (fromNodes x)
+    NodeFootnoteList items -> footnoteList (map fromNodes items)
+    NodeFootnoteRef x lab nodes -> footnoteRef x lab (fromNodes nodes)
+
+instance ToPlainText (NodeTypeFootnote a) where
+  toPlainText = \case
+    NodeFootnote num _ x -> T.pack (show num) <> ": " <> toPlainText x
+    NodeFootnoteList items -> T.unlines $ map toPlainText items
+    NodeFootnoteRef x _ _ -> "[" <> x <> "]"
+
+instance (Typeable a, HasFootnote a a) => HasFootnote (Nodes a) (Nodes a) where
+  footnote num lab x = singleNode $ NodeFootnote num lab x
+  footnoteList items = singleNode $ NodeFootnoteList items
+  footnoteRef x lab nodes = singleNode $ NodeFootnoteRef x lab nodes

--- a/commonmark-extensions/src/Commonmark/Extensions/Strikethrough.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/Strikethrough.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
 module Commonmark.Extensions.Strikethrough
   ( HasStrikethrough(..)
   , strikethroughSpec )
@@ -9,6 +12,8 @@ import Commonmark.Syntax
 import Commonmark.Inlines
 import Commonmark.SourceMap
 import Commonmark.Html
+import Commonmark.Nodes
+import Data.Typeable (Typeable)
 
 strikethroughSpec :: (Monad m, IsBlock il bl, IsInline il, HasStrikethrough il)
               => SyntaxSpec m il bl
@@ -27,3 +32,19 @@ instance HasStrikethrough (Html a) where
 instance (HasStrikethrough i, Monoid i)
         => HasStrikethrough (WithSourceMap i) where
   strikethrough x = (strikethrough <$> x) <* addName "strikethrough"
+
+data NodeTypeStrikethrough a
+  = NodeStrikethrough (Nodes a)
+  deriving (Show)
+
+instance (Typeable a, Monoid a, HasAttributes a, Rangeable a) => NodeType NodeTypeStrikethrough a where
+  type FromNodeType NodeTypeStrikethrough a = HasStrikethrough a
+  fromNodeType = \case
+    NodeStrikethrough x -> strikethrough (fromNodes x)
+
+instance ToPlainText (NodeTypeStrikethrough a) where
+  toPlainText = \case
+    NodeStrikethrough x -> toPlainText x
+
+instance (Typeable a, HasStrikethrough a, Monoid a, HasAttributes a, Rangeable a) => HasStrikethrough (Nodes a) where
+  strikethrough x = singleNode $ NodeStrikethrough x

--- a/commonmark-extensions/src/Commonmark/Extensions/TaskList.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/TaskList.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
 module Commonmark.Extensions.TaskList
   ( taskListSpec
   , HasTaskList (..)
@@ -17,11 +19,13 @@ import Commonmark.Blocks
 import Commonmark.SourceMap
 import Commonmark.TokParsers
 import Commonmark.Html
+import Commonmark.Nodes hiding (Node (..))
 import Control.Monad (mzero)
 import Control.Monad (when, guard)
 import Data.List (sort)
 import Data.Dynamic
 import Data.Tree
+import qualified Data.Text as T
 import Text.Parsec
 
 
@@ -228,3 +232,20 @@ instance (HasTaskList il bl, Semigroup bl, Semigroup il)
      (do let (checks, xs) = unzip items
          taskList lt spacing . zip checks <$> sequence xs
       ) <* addName "taskList"
+
+data NodeTypeTaskList a
+  = NodeTaskList ListType ListSpacing [(Bool, Nodes a)]
+  deriving (Show)
+
+instance Typeable a => NodeType NodeTypeTaskList a where
+  type FromNodeType NodeTypeTaskList a = HasTaskList a a
+  fromNodeType = \case
+    NodeTaskList lt spacing items -> taskList lt spacing (map (fmap fromNodes) items)
+
+instance ToPlainText (NodeTypeTaskList a) where
+  toPlainText = \case
+    NodeTaskList _ _ nodesList -> T.unlines $ map (toPlainText . snd) nodesList
+
+instance (Typeable a, HasTaskList a a) => HasTaskList (Nodes a) (Nodes a) where
+  taskList lt spacing items = singleNode $ NodeTaskList lt spacing items
+

--- a/commonmark/commonmark.cabal
+++ b/commonmark/commonmark.cabal
@@ -67,6 +67,7 @@ library
       Commonmark.Parser
       Commonmark.Types
       Commonmark.Html
+      Commonmark.Nodes
       Commonmark.Syntax
       Commonmark.ReferenceMap
       Commonmark.Tokens

--- a/commonmark/src/Commonmark/Nodes.hs
+++ b/commonmark/src/Commonmark/Nodes.hs
@@ -1,0 +1,208 @@
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+module Commonmark.Nodes
+  ( Nodes (..)
+  , singleNode
+  , fromNodes
+  , Node (..)
+  , getNodeType
+  , SomeNodeType (..)
+  , NodeType (..)
+  , NodeTypeBlock (..)
+  , NodeTypeInline (..)
+  , -- * Helpers
+    mapNodes
+  , traverseNodes
+  , concatMapNodes
+  )
+where
+
+import           Commonmark.Types
+import           Data.Kind (Constraint)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Data.Typeable        (Typeable, cast)
+
+-- | Nodes parsed from a markdown document, that can later be rendered
+-- to a value of type @a@ with 'fromNodes'.
+--
+-- An example filtering out all raw HTML content:
+--
+-- > let isRawHTML node
+-- >       | Just NodeRawInline{} <- getNodeType node = True
+-- >       | Just NodeRawBlock{} <- getNodeType node = True
+-- >       | otherwise = False
+-- > in Nodes . filter (not . isRawHTML) . unNodes
+newtype Nodes a = Nodes { unNodes :: [Node a] }
+  deriving (Show, Semigroup, Monoid)
+
+instance HasAttributes (Nodes a) where
+  addAttributes attrs = Nodes . map (\node -> node{nodeAttributes = nodeAttributes node <> attrs}) . unNodes
+
+instance ToPlainText (Nodes a) where
+  toPlainText = foldMap toPlainText . unNodes
+
+instance Rangeable (Nodes a) where
+  ranged sr = Nodes . map (\node -> node{nodeRange = Just sr}) . unNodes
+
+singleNode :: (NodeType node a, FromNodeType node a) => node a -> Nodes a
+singleNode nodeType = Nodes [Node (SomeNodeType nodeType) [] Nothing]
+
+fromNodes :: forall a. (Monoid a, HasAttributes a, Rangeable a) => Nodes a -> a
+fromNodes = foldMap fromNode . unNodes
+  where
+    fromNode :: Node a -> a
+    fromNode Node{nodeType = SomeNodeType nodeType, ..} =
+      maybe id ranged nodeRange
+        . addAttributes nodeAttributes
+        $ fromNodeType nodeType
+
+mapNodes :: (Node a -> Node a) -> Nodes a -> Nodes a
+mapNodes f = Nodes . map f . unNodes
+
+traverseNodes :: Applicative f => (Node a -> f (Node a)) -> Nodes a -> f (Nodes a)
+traverseNodes f = fmap Nodes . traverse f . unNodes
+
+concatMapNodes :: (Node a -> [Node a]) -> Nodes a -> Nodes a
+concatMapNodes f = Nodes . concatMap f . unNodes
+
+data Node a = Node
+  { nodeType :: SomeNodeType a
+  , nodeAttributes :: Attributes
+  , nodeRange :: Maybe SourceRange
+  }
+  deriving (Show)
+
+instance ToPlainText (Node a) where
+  toPlainText Node{nodeType = SomeNodeType nodeType, ..} =
+    case toPlainText nodeType of
+      "" | Just alt <- lookup "alt" nodeAttributes -> alt
+      t -> t
+
+getNodeType :: NodeType node a => Node a -> Maybe (node a)
+getNodeType = fromSomeNodeType . nodeType
+
+data SomeNodeType a = forall node. (NodeType node a, FromNodeType node a) => SomeNodeType (node a)
+
+instance Show (SomeNodeType a) where
+  show (SomeNodeType a) = show a
+
+class (Typeable (node a), Show (node a), ToPlainText (node a)) => NodeType node a where
+  type FromNodeType node a :: Constraint
+
+  fromSomeNodeType :: SomeNodeType a -> Maybe (node a)
+  fromSomeNodeType (SomeNodeType node) = cast node
+
+  fromNodeType :: FromNodeType node a => node a -> a
+
+data (NodeTypeInline a)
+  = NodeLineBreak
+  | NodeSoftBreak
+  | NodeStr Text
+  | NodeEntity Text
+  | NodeEscapedChar Char
+  | NodeEmph (Nodes a)
+  | NodeStrong (Nodes a)
+  | NodeLink Text Text (Nodes a)
+  | NodeImage Text Text (Nodes a)
+  | NodeCode Text
+  | NodeRawInline Format Text
+  deriving (Show)
+
+instance Typeable a => NodeType NodeTypeInline a where
+  type FromNodeType NodeTypeInline a = IsInline a
+  fromNodeType = \case
+    NodeLineBreak -> lineBreak
+    NodeSoftBreak -> softBreak
+    NodeStr t -> str t
+    NodeEntity t -> entity t
+    NodeEscapedChar c -> escapedChar c
+    NodeEmph nodes -> emph (fromNodes nodes)
+    NodeStrong nodes -> strong (fromNodes nodes)
+    NodeLink target title nodes -> link target title (fromNodes nodes)
+    NodeImage target title nodes -> image target title (fromNodes nodes)
+    NodeCode t -> code t
+    NodeRawInline fmt t -> rawInline fmt t
+
+instance ToPlainText (NodeTypeInline a) where
+  toPlainText = \case
+    NodeLineBreak -> T.singleton '\n'
+    NodeSoftBreak -> T.singleton '\n'
+    NodeStr t -> t
+    NodeEntity t -> t
+    NodeEscapedChar c -> T.singleton c
+    NodeEmph nodes -> toPlainText nodes
+    NodeStrong nodes -> toPlainText nodes
+    NodeLink _ _ nodes -> toPlainText nodes
+    NodeImage _ _ nodes -> toPlainText nodes
+    NodeCode t -> t
+    NodeRawInline _ _ -> mempty
+
+instance (Typeable a, IsInline a) => IsInline (Nodes a) where
+  lineBreak = singleNode NodeLineBreak
+  softBreak = singleNode NodeSoftBreak
+  str t = singleNode $ NodeStr t
+  entity t = singleNode $ NodeEntity t
+  escapedChar c = singleNode $ NodeEscapedChar c
+  emph nodes = singleNode $ NodeEmph nodes
+  strong nodes = singleNode $ NodeStrong nodes
+  link target title nodes = singleNode $ NodeLink target title nodes
+  image target title nodes = singleNode $ NodeImage target title nodes
+  code t = singleNode $ NodeCode t
+  rawInline f t = singleNode $ NodeRawInline f t
+
+data NodeTypeBlock a
+  = NodeParagraph (Nodes a)
+  | NodePlain (Nodes a)
+  | NodeThematicBreak
+  | NodeBlockQuote (Nodes a)
+  | NodeCodeBlock Text Text
+  | NodeHeading Int (Nodes a)
+  | NodeRawBlock Format Text
+  | NodeReferenceLinkDefinition Text (Text, Text)
+  | NodeList ListType ListSpacing [Nodes a]
+  deriving (Show)
+
+instance Typeable a => NodeType NodeTypeBlock a where
+  type FromNodeType NodeTypeBlock a = IsBlock a a
+  fromNodeType = \case
+    NodeParagraph nodes -> paragraph (fromNodes nodes)
+    NodePlain nodes -> plain (fromNodes nodes)
+    NodeThematicBreak -> thematicBreak
+    NodeBlockQuote nodes -> blockQuote (fromNodes nodes)
+    NodeCodeBlock info t -> codeBlock info t
+    NodeHeading num nodes -> heading num (fromNodes nodes)
+    NodeRawBlock fmt t -> rawBlock fmt t
+    NodeReferenceLinkDefinition lab dest -> referenceLinkDefinition lab dest
+    NodeList lType lSpacing nodesList -> list lType lSpacing (map fromNodes nodesList)
+
+instance ToPlainText (NodeTypeBlock a) where
+  toPlainText = \case
+    NodeParagraph nodes -> toPlainText nodes
+    NodePlain nodes -> toPlainText nodes
+    NodeThematicBreak -> mempty
+    NodeBlockQuote nodes -> toPlainText nodes
+    NodeCodeBlock _ t -> t
+    NodeHeading _ nodes -> toPlainText nodes
+    NodeRawBlock _ _ -> mempty
+    NodeReferenceLinkDefinition _ _ -> mempty
+    NodeList _ _ nodesList -> T.unlines $ map toPlainText nodesList
+
+instance (Typeable a, IsBlock a a) => IsBlock (Nodes a) (Nodes a) where
+  paragraph nodes = singleNode $ NodeParagraph nodes
+  plain nodes = singleNode $ NodePlain nodes
+  thematicBreak = singleNode $ NodeThematicBreak
+  blockQuote nodes = singleNode $ NodeBlockQuote nodes
+  codeBlock info t = singleNode $ NodeCodeBlock info t
+  heading level nodes = singleNode $ NodeHeading level nodes
+  rawBlock f t = singleNode $ NodeRawBlock f t
+  referenceLinkDefinition target dest = singleNode $ NodeReferenceLinkDefinition target dest
+  list lType lSpacing nodesList = singleNode $ NodeList lType lSpacing nodesList


### PR DESCRIPTION
Tested in GHCi:
```hs
ghci> import Commonmark.Nodes

ghci> commonmark "foo.md" "# hello\n```haskell\nx = 1\n```" :: Either ParseError (Nodes (Html ()))
Right (Nodes {unNodes = [Node {nodeType = NodeHeading 1 (Nodes {unNodes = [Node {nodeType = NodeStr "hello", nodeAttributes = [], nodeRange = Just foo.md@1:3-1:8}]}), nodeAttributes = [], nodeRange = Just foo.md@1:1-2:1},Node {nodeType = NodeCodeBlock "haskell" "x = 1\n", nodeAttributes = [], nodeRange = Just foo.md@2:1-5:1},Node {nodeType = NodeParagraph (Nodes {unNodes = []}), nodeAttributes = [], nodeRange = Just foo.md@4:4-5:1}]})

ghci> fromNodes <$> commonmark "foo.md" "# hello\n```haskell\nx = 1\n```" :: Either ParseError (Html ())
Right <h1>hello</h1>
<pre><code class="language-haskell">x = 1
</code></pre>
<p></p>
```