### PR TITLE
commonmark: re-export Text.Parsec.Pos accessors

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/RebaseRelativePaths.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/RebaseRelativePaths.hs
@@ -11,7 +11,6 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Maybe (fromMaybe)
 import Text.Parsec (getPosition)
-import Text.Parsec.Pos (sourceName)
 import System.FilePath
 import qualified System.FilePath.Windows as Windows
 import qualified System.FilePath.Posix as Posix

--- a/commonmark/src/Commonmark/Types.hs
+++ b/commonmark/src/Commonmark/Types.hs
@@ -12,12 +12,14 @@ module Commonmark.Types
   , IsInline(..)
   , IsBlock(..)
   , SourceRange(..)
-  , SourcePos
   , Rangeable(..)
   , Attribute
   , Attributes
   , HasAttributes(..)
   , ToPlainText(..)
+
+  -- * Re-exports
+  , module Text.Parsec.Pos
   )
 where
 import           Data.Data            (Data)


### PR DESCRIPTION
To deal robustly with source positions of document elements (e.g. for deletion or alteration) we need to be able to drill into the SourcePos values in the SourceRange.  It is a bit of a nuisance to require users to have a direct dependency on *parsec* just to get at `sourceLine` and `sourceColumn`.  Re-export them from `Commonmark.Types`.

Fixes: https://github.com/jgm/commonmark-hs/issues/106