### PR TITLE
Fix pipe table parser interfering with other block structures

### DIFF
--- a/commonmark-extensions/test/pipe_tables.md
+++ b/commonmark-extensions/test/pipe_tables.md
@@ -264,3 +264,51 @@ A table may be indented up to three spaces:
 </code></pre>
 ````````````````````````````````
 
+
+Pipe tables have exactly one header row, and do not interrupt paragraphs.
+
+```````````````````````````````` example
+| Too much table | to be considered table |
+| Too much table | to be considered table |
+|----------------|------------------------|
+| Too much table | to be considered table |
+.
+<p>| Too much table | to be considered table |
+| Too much table | to be considered table |
+|----------------|------------------------|
+| Too much table | to be considered table |</p>
+````````````````````````````````
+
+
+Other block structures, like headers, have higher priority than tables.
+Tables can be nested in other elements, but don't benefit from laziness.
+
+```````````````````````````````` example
+# abc | def
+------|-----
+
+
+> abc | def
+> ----|-----
+
+
+> abc | def
+----|-----
+.
+<h1>abc | def</h1>
+<p>------|-----</p>
+<blockquote>
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+</table>
+</blockquote>
+<blockquote>
+<p>abc | def
+----|-----</p>
+</blockquote>
+````````````````````````````````


### PR DESCRIPTION
Fixes #52

```console
$ cabal run commonmark-cli -- -xmath -xpipe_tables
Up to date
Examples:

* $|x| = 2$
* other example
^D
<p>Examples:</p>
<ul>
<li><span class="math inline">\(|x| = 2\)</span>
</li>
<li>other example
</li>
</ul>

$ cabal run commonmark-cli -- -xmath -xpipe_tables -xfenced_divs
Up to date
::: {foo="hi|there|ok"}
hi
:::
^D
<div data-foo="hi|there|ok">
<p>hi</p>
</div>
```

Fixes #95

```console
$ cabal run commonmark-cli -- -xmath -xpipe_tables -xfenced_divs
Up to date
- foo
- `a|b`
- bar
^D
<ul>
<li>foo
</li>
<li><code>a|b</code>
</li>
<li>bar
</li>
</ul>
```

This parser is structured as a system that parses the *second* line first, then parses the first line. That is, if it detects a delimiter row as the second line of a paragraph, it converts the paragraph into a table. This seems counterintuitive, but it works better than trying to convert a table into a paragraph, since it might need to be something else.

As a comparison with GitHub:

  * GitHub allows tables to interrupt paragraphs, but this parser doesn't. The old parser didn't used to support this, either, so it's not a regression.
  * The odd behavior where tables don't get lazily continued is actually the same thing GitHub and pulldown-cmark both do.