### PR TITLE
Make pipe_tables extension treat backslash escapes like GH does

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/PipeTable.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/PipeTable.hs
@@ -88,11 +88,9 @@ pCells = try $ do
 pCell :: Monad m => ParsecT [Tok] s m [Tok]
 pCell = mconcat <$> many1
   ( try
-      (do tok' <- symbol '\\'
-          tok@(Tok (Symbol c) _ _) <- anySymbol
-          if c == '|'
-             then return $! [tok]
-             else return $! [tok',tok])
+      (do symbol '\\'
+          tok <- symbol '|'
+          return $! [tok])
   <|> (do tok <- (satisfyTok $ \t -> not (hasType (Symbol '|') t ||
                                        hasType LineEnd t))
           return $! [tok])

--- a/commonmark-extensions/test/pipe_tables.md
+++ b/commonmark-extensions/test/pipe_tables.md
@@ -312,3 +312,126 @@ Tables can be nested in other elements, but don't benefit from laziness.
 ----|-----</p>
 </blockquote>
 ````````````````````````````````
+
+
+As a special case, pipes in inline code in tables are escaped
+with backslashes.
+
+The parsing rule for CommonMark is that block structures are parsed before
+inline structures are. Normally, this means backslashes aren't allowed to have
+any effect on block structures at all. Tables do consider backslashes, but
+not the same way inline syntax does: they have higher precedence than anything
+else, as-if they were parsed in a completely separate pass.
+
+This rule should be identical to GitHub's. See
+<https://gist.github.com/notriddle/c027512ee849f12098fec3a3256c89d3>
+for what they do.
+
+This changes the behavior from what older versions of commonmark-extensions do,
+but it fixes some expressiveness holes that hit older versions.
+
+```````````````````````````````` example
+| Description | Test case |
+|-------------|-----------|
+| Single      | `\`       |
+| Double      | `\\`      |
+| Basic test  | `\|`      |
+| Basic test 2| `\|\|\`   |
+| Basic test 3| `x\|y\|z\`|
+| Not pipe    | `\.`      |
+| Combo       | `\.\|\`   |
+| Extra       | `\\\.`    |
+| Wait, what? | `\\|`     |
+| Wait, what? | `\\\|`    |
+| Wait, what? | `\\\\|`   |
+| Wait, what? | `\\\\\|`  |
+| Wait, what? |          \|
+| Wait, what? |         \\|
+| Wait, what? |        \\\|
+| Wait, what?x|          \|x
+| Wait, what?x|         \\|x
+| Wait, what?x|        \\\|x
+.
+<table>
+<thead>
+<tr>
+<th>Description</th>
+<th>Test case</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Single</td>
+<td><code>\</code></td>
+</tr>
+<tr>
+<td>Double</td>
+<td><code>\\</code></td>
+</tr>
+<tr>
+<td>Basic test</td>
+<td><code>|</code></td>
+</tr>
+<tr>
+<td>Basic test 2</td>
+<td><code>||\</code></td>
+</tr>
+<tr>
+<td>Basic test 3</td>
+<td><code>x|y|z\</code></td>
+</tr>
+<tr>
+<td>Not pipe</td>
+<td><code>\.</code></td>
+</tr>
+<tr>
+<td>Combo</td>
+<td><code>\.|\</code></td>
+</tr>
+<tr>
+<td>Extra</td>
+<td><code>\\\.</code></td>
+</tr>
+<tr>
+<td>Wait, what?</td>
+<td><code>\|</code></td>
+</tr>
+<tr>
+<td>Wait, what?</td>
+<td><code>\\|</code></td>
+</tr>
+<tr>
+<td>Wait, what?</td>
+<td><code>\\\|</code></td>
+</tr>
+<tr>
+<td>Wait, what?</td>
+<td><code>\\\\|</code></td>
+</tr>
+<tr>
+<td>Wait, what?</td>
+<td>|</td>
+</tr>
+<tr>
+<td>Wait, what?</td>
+<td>|</td>
+</tr>
+<tr>
+<td>Wait, what?</td>
+<td>\|</td>
+</tr>
+<tr>
+<td>Wait, what?x</td>
+<td>|x</td>
+</tr>
+<tr>
+<td>Wait, what?x</td>
+<td>|x</td>
+</tr>
+<tr>
+<td>Wait, what?x</td>
+<td>\|x</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````


### PR DESCRIPTION
This change essentially changes the way the text `\\|` gets parsed inside a table. In the old version, the first backslash escapes the second backslash, and then the pipe is treated as a cell separator. In the new version, the pipe is still preceded by a backslash, so it is still literal text.

This change seems reasonable, because if you want the pipe to act as a separator, you can always separate it from the cell contents with a space in the new system, but if you want to write the literal text `\|` inside a cell in the old system, you can't.