### PR TITLE
Parse [^] as a link

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/Footnote.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/Footnote.hs
@@ -25,7 +25,7 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Dynamic
 import Data.Tree
 import Text.Parsec
-import Data.Text (Text)
+import Data.Text (Text, empty)
 import qualified Data.Text as T
 import qualified Data.Map as M
 
@@ -103,7 +103,7 @@ pFootnoteLabel :: Monad m => ParsecT [Tok] u m Text
 pFootnoteLabel = try $ do
   lab <- pLinkLabel
   case T.uncons lab of
-        Just ('^', t') -> return $! t'
+        Just ('^', t') | t' /= Data.Text.empty -> return $! t'
         _ -> mzero
 
 pFootnoteRef :: (Monad m, Typeable m, Typeable a,

--- a/commonmark-extensions/test/footnotes.md
+++ b/commonmark-extensions/test/footnotes.md
@@ -134,3 +134,13 @@ Footnote containing a list[^list]
 </div>
 </section>
 ````````````````````````````````
+
+Footnote labels cannot be empty.
+
+```````````````````````````````` example
+Test [^] link
+
+[^]: https://haskell.org
+.
+<p>Test <a href="https://haskell.org">^</a> link</p>
+````````````````````````````````


### PR DESCRIPTION
This is consistent with most other CommonMark parsers, even when they have support for footnotes turned on.

Fixes #117 