### PR TITLE
Fix incorrectly parsing links with nested `[]`

### DIFF
--- a/commonmark/test/regression.md
+++ b/commonmark/test/regression.md
@@ -219,3 +219,19 @@ x
 <pre><code class="language-\">x
 </code></pre>
 ````````````````````````````````
+
+Issue #119
+```````````````````````````````` example
+[[]](https://haskell.org)
+
+[[][]](https://haskell.org)
+
+[[[][]](https://haskell.org)
+
+[[][][]](https://haskell.org)
+.
+<p><a href="https://haskell.org">[]</a></p>
+<p><a href="https://haskell.org">[][]</a></p>
+<p>[<a href="https://haskell.org">[][]</a></p>
+<p><a href="https://haskell.org">[][][]</a></p>
+````````````````````````````````


### PR DESCRIPTION
Fixes #119

This markdown input:

```markdown
[[]](https://haskell.org)

[[][]](https://haskell.org)

[[[][]](https://haskell.org)

[[][][]](https://haskell.org)
```

In commonmark-hs, [it used to make this HTML](https://pandoc.org/try/?params=%7B%22text%22%3A%22%5B%5B%5D%5D%28https%3A%2F%2Fhaskell.org%29%5Cn%5Cn%5B%5B%5D%5B%5D%5D%28https%3A%2F%2Fhaskell.org%29%5Cn%5Cn%5B%5B%5B%5D%5B%5D%5D%28https%3A%2F%2Fhaskell.org%29%5Cn%5Cn%5B%5B%5D%5B%5D%5B%5D%5D%28https%3A%2F%2Fhaskell.org%29%22%2C%22to%22%3A%22html5%22%2C%22from%22%3A%22commonmark_x%22%2C%22standalone%22%3Afalse%2C%22embed-resources%22%3Afalse%2C%22table-of-contents%22%3Afalse%2C%22number-sections%22%3Afalse%2C%22citeproc%22%3Afalse%2C%22html-math-method%22%3A%22plain%22%2C%22wrap%22%3A%22auto%22%2C%22highlight-style%22%3Anull%2C%22files%22%3A%7B%7D%2C%22template%22%3Anull%7D):

```html
<p><a href="https://haskell.org">[]</a></p>
<p>[<a href="https://haskell.org">][]</a></p>
<p>[[<a href="https://haskell.org">][]</a></p>
<p>[[]<a href="https://haskell.org">][]</a></p>
```

In commonmark.js, [it makes this instead](https://spec.commonmark.org/dingus/?text=%5B%5B%5D%5D(https%3A%2F%2Fhaskell.org)%0A%0A%5B%5B%5D%5B%5D%5D(https%3A%2F%2Fhaskell.org)%0A%0A%5B%5B%5B%5D%5B%5D%5D(https%3A%2F%2Fhaskell.org)%0A%0A%5B%5B%5D%5B%5D%5B%5D%5D(https%3A%2F%2Fhaskell.org)):

```html
<p><a href="https://haskell.org">[]</a></p>
<p><a href="https://haskell.org">[][]</a></p>
<p>[<a href="https://haskell.org">[][]</a></p>
<p><a href="https://haskell.org">[][][]</a></p>
```

The commonmark.js output seems to be correct according to the specification:

> Brackets are allowed in the [link text](https://spec.commonmark.org/0.30/#link-text)
> only if (a) they are backslash-escaped or (b) they appear as a
> matched pair of brackets, with an open bracket `[`, a sequence of
> zero or more inlines, and a close bracket `]`.