### PR TITLE
Parse `[^ ]` as a link

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/Footnote.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/Footnote.hs
@@ -25,7 +25,7 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Dynamic
 import Data.Tree
 import Text.Parsec
-import Data.Text (Text, empty)
+import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Map as M
 
@@ -103,7 +103,8 @@ pFootnoteLabel :: Monad m => ParsecT [Tok] u m Text
 pFootnoteLabel = try $ do
   lab <- pLinkLabel
   case T.uncons lab of
-        Just ('^', t') | t' /= Data.Text.empty -> return $! t'
+        Just ('^', t') | T.any (\x -> x /= ' ' && x /= '\t' && x /= '\r' && x /= '\n') t'
+            -> return $! t'
         _ -> mzero
 
 pFootnoteRef :: (Monad m, Typeable m, Typeable a,

--- a/commonmark-extensions/test/footnotes.md
+++ b/commonmark-extensions/test/footnotes.md
@@ -135,12 +135,26 @@ Footnote containing a list[^list]
 </section>
 ````````````````````````````````
 
-Footnote labels cannot be empty.
+Footnote labels cannot be empty, or composed only of whitespace.
 
 ```````````````````````````````` example
-Test [^] link
+Test [^] link [^ ]
 
 [^]: https://haskell.org
 .
-<p>Test <a href="https://haskell.org">^</a> link</p>
+<p>Test <a href="https://haskell.org">^</a> link <a href="https://haskell.org">^ </a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[^]: not a footnote
+
+[^ ]: not a footnote
+
+[^
+]: not a footnote
+.
+<p>[^]: not a footnote</p>
+<p>[^ ]: not a footnote</p>
+<p>[^
+]: not a footnote</p>
 ````````````````````````````````


### PR DESCRIPTION
This matches the behavior of GitHub, etc more closely.