### PR TITLE
Avoid adding trailing newline to list block if it's already there

### DIFF
--- a/commonmark/src/Commonmark/Blocks.hs
+++ b/commonmark/src/Commonmark/Blocks.hs
@@ -940,7 +940,11 @@ listSpec = BlockSpec
           blockBlanks' <- case childrenData of
                              c:_ | listItemBlanksAtEnd c -> do
                                  curline <- sourceLine <$> getPosition
-                                 return $! curline - 1 : blockBlanks cdata
+                                 return $! case blockBlanks cdata of
+                                    lb:b | lb == curline - 1 ->
+                                        lb:b
+                                    b ->
+                                       curline - 1 : b
                              _ -> return $! blockBlanks cdata
           let ldata' = toDyn (ListData lt ls)
           -- need to transform paragraphs on tight lists

--- a/commonmark/test/regression.md
+++ b/commonmark/test/regression.md
@@ -235,3 +235,20 @@ Issue #119
 <p>[<a href="https://haskell.org">[][]</a></p>
 <p><a href="https://haskell.org">[][][]</a></p>
 ````````````````````````````````
+
+Issue #122
+```````````````````````````````` example
+* x
+* -
+
+
+Test
+.
+<ul>
+<li>x</li>
+<li><ul>
+<li></li>
+</ul></li>
+</ul>
+<p>Test</p>
+````````````````````````````````


### PR DESCRIPTION
Fixes #122

This can happen because of the two-line limit on blank list items, as seen in this markdown sample, marked up with line numbers

```text
 1 | * x
 2 | * -
   |     ^ first blank line of ListItem
 3 |
   |     ^ second, final blank line of ListItem
 4 |
   |   ^ blank line is part of List, not ListItem
 5 | Test
```

The list item has `listItemBlanksAtEnd = True`, because of line 3, but line 4 gets added to the List's blockBlanks. This means blockFinalize should avoid adding it, otherwise you get `blockBlanks' = [4, 4]` and that causes it to spurriously be parsed as loose.