### PR TITLE
Do not accept footnote definitions with line breaks

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/Footnote.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/Footnote.hs
@@ -101,9 +101,12 @@ footnoteBlockSpec = BlockSpec
 
 pFootnoteLabel :: Monad m => ParsecT [Tok] u m Text
 pFootnoteLabel = try $ do
-  lab <- pLinkLabel
+  lab <- untokenize
+      <$> try (between (symbol '[') (symbol ']')
+            (snd <$> withRaw (many
+              (pEscaped <|> noneOfToks [Symbol ']', Symbol '[', LineEnd]))))
   case T.uncons lab of
-        Just ('^', t') | T.any (\x -> x /= ' ' && x /= '\t' && x /= '\r' && x /= '\n') t'
+        Just ('^', t') | T.any (\x -> x /= ' ' && x /= '\t') t' && T.all (\x -> x /= '\n' && x /= '\r') t'
             -> return $! t'
         _ -> mzero
 

--- a/commonmark-extensions/test/footnotes.md
+++ b/commonmark-extensions/test/footnotes.md
@@ -158,3 +158,41 @@ Test [^] link [^ ]
 <p>[^
 ]: not a footnote</p>
 ````````````````````````````````
+
+Footnote labels cannot contain line breaks, even where link labels can.
+
+```````````````````````````````` example
+[^foo\
+bar]: not a footnote definition
+
+[baz\
+quux]: https://haskell.org
+
+[first
+second]: https://haskell.org
+
+[^third
+fourth]: not a footnote definition
+
+[baz\
+quux]
+[^foo\
+bar]
+[first
+second]
+[^third
+fourth]
+.
+<p>[^foo<br />
+bar]: not a footnote definition</p>
+<p>[^third
+fourth]: not a footnote definition</p>
+<p><a href="https://haskell.org">baz<br />
+quux</a>
+[^foo<br />
+bar]
+<a href="https://haskell.org">first
+second</a>
+[^third
+fourth]</p>
+````````````````````````````````


### PR DESCRIPTION
Fixes #124

This change brings commonmark-hs into alignment with [markdown-it] and hugo/goldmark. It's close to GitHub, but GitHub [doesn't parse the backslashes as hard line breaks][gist].

It's odd that link reference definitions are allowed to have line breaks and footnote definitions aren't, but it's not worth it to be gratuitously different.

[markdown-it]: https://markdown-it.github.io/#md3=%7B%22source%22%3A%22%5B%5Efoo%5C%5C%5Cnbar%5D%3A%20not%20a%20footnote%20definition%5Cn%5Cn%5Bbaz%5C%5C%5Cnquux%5D%3A%20https%3A%2F%2Frust-lang.org%5Cn%5Cn%5Bfirst%5Cnsecond%5D%3A%20https%3A%2F%2Frust-lang.org%5Cn%5Cn%5B%5Ethird%5Cnfourth%5D%3A%20not%20a%20footnote%20definition%5Cn%5Cn%5Bbaz%5C%5C%5Cnquux%5D%5Cn%5B%5Efoo%5C%5C%5Cnbar%5D%5Cn%5Bfirst%5Cnsecond%5D%5Cn%5B%5Ethird%5Cnfourth%5D%22%2C%22defaults%22%3A%7B%22html%22%3Afalse%2C%22xhtmlOut%22%3Afalse%2C%22breaks%22%3Afalse%2C%22langPrefix%22%3A%22language-%22%2C%22linkify%22%3Atrue%2C%22typographer%22%3Atrue%2C%22_highlight%22%3Atrue%2C%22_strict%22%3Afalse%2C%22_view%22%3A%22html%22%7D%7D

[gist]: https://gist.github.com/notriddle/7fd2410a2585123ad0f894b08c58b21f