### PR TITLE
Parse footnote definitions with lazy continuation

### DIFF
--- a/commonmark-extensions/test/footnotes.md
+++ b/commonmark-extensions/test/footnotes.md
@@ -196,3 +196,59 @@ second</a>
 [^third
 fourth]</p>
 ````````````````````````````````
+
+Only the first line of a footnote's following paragraph needs indented.
+
+```````````````````````````````` example
+[^foo]:bar
+baz
+
+    quux
+arst
+    qwfp
+
+[^foo]
+.
+<p><sup class="footnote-ref"><a href="#fn-foo" id="fnref-foo">1</a></sup></p>
+<section class="footnotes">
+<div class="footnote" id="fn-foo">
+<div class="footnote-number">
+<a href="#fnref-foo">1</a>
+</div>
+<div class="footnote-contents">
+<p>bar
+baz</p>
+<p>quux
+arst
+qwfp</p>
+</div>
+</div>
+</section>
+````````````````````````````````
+
+Lazy continuations require the first line to have text in it,
+and to lazily continue a paragraph after the first, it will need to
+start with an indented line also.
+
+```````````````````````````````` example
+[^foo]:
+baz
+
+    quux
+
+[^foo]
+.
+<p>baz</p>
+<pre><code>quux
+</code></pre>
+<p><sup class="footnote-ref"><a href="#fn-foo" id="fnref-foo">1</a></sup></p>
+<section class="footnotes">
+<div class="footnote" id="fn-foo">
+<div class="footnote-number">
+<a href="#fnref-foo">1</a>
+</div>
+<div class="footnote-contents">
+</div>
+</div>
+</section>
+````````````````````````````````


### PR DESCRIPTION
Fixes #126

This change brings it into alignment with GitHub, [markdown-it](https://markdown-it.github.io/#md3=%7B%22source%22%3A%22%5B%5Efoo%5D%3Abar%5Cnbaz%5Cn%5Cn%20%20%20%20quux%5Cnarst%5Cn%20%20%20%20qwfp%5Cn%5Cn%5B%5Efoo%5D%22%2C%22defaults%22%3A%7B%22html%22%3Afalse%2C%22xhtmlOut%22%3Afalse%2C%22breaks%22%3Afalse%2C%22langPrefix%22%3A%22language-%22%2C%22linkify%22%3Atrue%2C%22typographer%22%3Atrue%2C%22_highlight%22%3Atrue%2C%22_strict%22%3Afalse%2C%22_view%22%3A%22html%22%7D%7D), and hugo/goldmark.