### PR TITLE
Specifically track the position where enders end

### DIFF
--- a/commonmark/test/regression.md
+++ b/commonmark/test/regression.md
@@ -307,3 +307,32 @@ Issue #133
 <p>zz</p></li>
 </ul>
 ````````````````````````````````
+
+
+Issue #139
+```````````````````````````````` example
+Test <?xml?> <?xml?>
+
+Test <?xml?> x <?xml?>
+
+Test <![CDATA[ x ]]> <![CDATA[ x ]]>
+
+Test <![CDATA[ x ]]> x <![CDATA[ x ]]>
+
+Test <!DOCTYPE html> <!DOCTYPE html>
+
+Test <!DOCTYPE html> x <!DOCTYPE html>
+
+Test <span> <span>
+
+Test <span> x <span>
+.
+<p>Test <?xml?> <?xml?></p>
+<p>Test <?xml?> x <?xml?></p>
+<p>Test <![CDATA[ x ]]> <![CDATA[ x ]]></p>
+<p>Test <![CDATA[ x ]]> x <![CDATA[ x ]]></p>
+<p>Test <!DOCTYPE html> <!DOCTYPE html></p>
+<p>Test <!DOCTYPE html> x <!DOCTYPE html></p>
+<p>Test <span> <span></p>
+<p>Test <span> x <span></p>
+````````````````````````````````


### PR DESCRIPTION
Build upon a5f381eb6548124ba71744e6d4ad39f93d2c2be3 to make it work correctly when the same type of item appears twice.

Compare this code with pulldown-cmark's HtmlScanGuard:

https://github.com/raphlinus/pulldown-cmark/pull/281/files#diff-5583e398a8deec11b274d9965eff8b5ade5226c7a020ca214a27d7d07dcc8a29R1744-R1748

Fixes #139 