### PR TITLE
Track wikilinks with a class instead of the title

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/Wikilinks.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/Wikilinks.hs
@@ -23,7 +23,7 @@ class HasWikilinks il where
   wikilink :: Text -> il -> il
 
 instance Rangeable (Html a) => HasWikilinks (Html a) where
-  wikilink url il = link url "wikilink" il
+  wikilink url il =  addAttribute ("class", "wikilink") $ link url "" il
 
 instance (HasWikilinks il, Semigroup il, Monoid il)
         => HasWikilinks (WithSourceMap il) where

--- a/commonmark-extensions/test/wikilinks_title_after_pipe.md
+++ b/commonmark-extensions/test/wikilinks_title_after_pipe.md
@@ -10,25 +10,25 @@ With this version of wikilinks, the title comes after the pipe.
 ```````````````````````````````` example
 [[https://example.org]]
 .
-<p><a href="https://example.org" title="wikilink">https://example.org</a></p>
+<p><a class="wikilink" href="https://example.org">https://example.org</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[https://example.org|title]]
 .
-<p><a href="https://example.org" title="wikilink">title</a></p>
+<p><a class="wikilink" href="https://example.org">title</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[Name of page]]
 .
-<p><a href="Name%20of%20page" title="wikilink">Name of page</a></p>
+<p><a class="wikilink" href="Name%20of%20page">Name of page</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[Name of page|Title]]
 .
-<p><a href="Name%20of%20page" title="wikilink">Title</a></p>
+<p><a class="wikilink" href="Name%20of%20page">Title</a></p>
 ````````````````````````````````
 
 HTML entities are recognized both in the name of page and in the link title.
@@ -36,5 +36,5 @@ HTML entities are recognized both in the name of page and in the link title.
 ```````````````````````````````` example
 [[Gesch&uuml;tztes Leerzeichen|&#xDC;ber &amp;nbsp;]]
 .
-<p><a href="Gesch%C3%BCtztes%20Leerzeichen" title="wikilink">Über &amp;nbsp;</a></p>
+<p><a class="wikilink" href="Gesch%C3%BCtztes%20Leerzeichen">Über &amp;nbsp;</a></p>
 ````````````````````````````````

--- a/commonmark-extensions/test/wikilinks_title_before_pipe.md
+++ b/commonmark-extensions/test/wikilinks_title_before_pipe.md
@@ -10,25 +10,25 @@ With this version of wikilinks, the title comes before the pipe.
 ```````````````````````````````` example
 [[https://example.org]]
 .
-<p><a href="https://example.org" title="wikilink">https://example.org</a></p>
+<p><a class="wikilink" href="https://example.org">https://example.org</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[title|https://example.org]]
 .
-<p><a href="https://example.org" title="wikilink">title</a></p>
+<p><a class="wikilink" href="https://example.org">title</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[Name of page]]
 .
-<p><a href="Name%20of%20page" title="wikilink">Name of page</a></p>
+<p><a class="wikilink" href="Name%20of%20page">Name of page</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[Title|Name of page]]
 .
-<p><a href="Name%20of%20page" title="wikilink">Title</a></p>
+<p><a class="wikilink" href="Name%20of%20page">Title</a></p>
 ````````````````````````````````
 
 Regular links should still work!
@@ -44,5 +44,5 @@ HTML entities are recognized both in the name of page and in the link title.
 ```````````````````````````````` example
 [[&#xDC;ber &amp;nbsp;|Gesch&uuml;tztes Leerzeichen]]
 .
-<p><a href="Gesch%C3%BCtztes%20Leerzeichen" title="wikilink">Über &amp;nbsp;</a></p>
+<p><a class="wikilink" href="Gesch%C3%BCtztes%20Leerzeichen">Über &amp;nbsp;</a></p>
 ````````````````````````````````

--- a/commonmark-pandoc/src/Commonmark/Pandoc.hs
+++ b/commonmark-pandoc/src/Commonmark/Pandoc.hs
@@ -120,7 +120,7 @@ instance HasEmoji (Cm b B.Inlines) where
                   $ B.text t
 
 instance HasWikilinks (Cm b B.Inlines) where
-  wikilink t il = Cm $ B.link t "wikilink" $ unCm il
+  wikilink t il = Cm $ B.linkWith (mempty, ["wikilink"], mempty) t "" $ unCm il
 
 instance HasPipeTable (Cm a B.Inlines) (Cm a B.Blocks) where
   pipeTable aligns headerCells rows =


### PR DESCRIPTION
The use of title="wikilink" in HTML output likely traces back to Pandoc's hijacking of the title attribute for this purpose back when Pandoc links didn't have Attrs. A coordinated change in Pandoc moves this more appropriately into a class.
