### PR TITLE
Fix tasklist parsing bugs

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/TaskList.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/TaskList.hs
@@ -133,6 +133,17 @@ taskListItemBlockSpec = BlockSpec
                                listItemType lidata
                     -> addNodeToStack linode
                   _ -> addNodeToStack listnode >> addNodeToStack linode
+             blankAfterMarker <- optionMaybe lineEnd
+             pos' <- getPosition
+             case blankAfterMarker of
+                  Just _ -> return ()
+                  Nothing -> do
+                    toks <- many (satisfyTok (not . hasType LineEnd))
+                    addNodeToStack $
+                        Node (defBlockData paraSpec){
+                              blockStartPos = [pos']
+                            , blockLines = [toks] }
+                        []
              return BlockStartMatch
      , blockCanContain     = const True
      , blockContainsLines  = False

--- a/commonmark-extensions/src/Commonmark/Extensions/TaskList.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/TaskList.hs
@@ -133,7 +133,7 @@ taskListItemBlockSpec = BlockSpec
                                listItemType lidata
                     -> addNodeToStack linode
                   _ -> addNodeToStack listnode >> addNodeToStack linode
-             blankAfterMarker <- optionMaybe lineEnd
+             blankAfterMarker <- optionMaybe blankLine
              pos' <- getPosition
              case blankAfterMarker of
                   Just _ -> return ()

--- a/commonmark-extensions/src/Commonmark/Extensions/TaskList.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/TaskList.hs
@@ -184,11 +184,11 @@ itemStart = do
   pos <- getPosition
   ty <- bulletListMarker
   aftercol <- sourceColumn <$> getPosition
-  checked <- parseCheckbox
   lookAhead whitespace
   numspaces <- try (gobbleUpToSpaces 4 <* notFollowedBy whitespace)
            <|> gobbleSpaces 1
-           <|> 1 <$ lookAhead lineEnd
+  checked <- parseCheckbox
+  lookAhead whitespace
   return $! (pos, ListItemData{
             listItemType = ty
           , listItemChecked = checked

--- a/commonmark-extensions/test/task_lists.md
+++ b/commonmark-extensions/test/task_lists.md
@@ -69,3 +69,25 @@ As in GitHub-flavored Markdown.
 </blockquote></li>
 </ul>
 ````````````````````````````````
+
+There is no empty paragraph after the `]`.
+
+```````````````````````````````` example
+- [x] * some text
+
+- [x]
+
+  some text
+
+- [x]→
+
+  some text
+.
+<ul class="task-list">
+<li><input type="checkbox" disabled="" checked="" /><p>* some text</p></li>
+<li><input type="checkbox" disabled="" checked="" /><p>some text</p>
+</li>
+<li><input type="checkbox" disabled="" checked="" /><p>some text</p>
+</li>
+</ul>
+````````````````````````````````

--- a/commonmark-extensions/test/task_lists.md
+++ b/commonmark-extensions/test/task_lists.md
@@ -28,3 +28,23 @@ As in GitHub-flavored Markdown.
 </ul>
 ````````````````````````````````
 
+
+```````````````````````````````` example
+- [x]unreal
+.
+<ul>
+<li>[x]unreal</li>
+</ul>
+````````````````````````````````
+
+
+```````````````````````````````` example
+-  [x] real
+
+  not indented enough
+.
+<ul class="task-list">
+<li><input type="checkbox" disabled="" checked="" />real</li>
+</ul>
+<p>not indented enough</p>
+````````````````````````````````

--- a/commonmark-extensions/test/task_lists.md
+++ b/commonmark-extensions/test/task_lists.md
@@ -48,3 +48,24 @@ As in GitHub-flavored Markdown.
 </ul>
 <p>not indented enough</p>
 ````````````````````````````````
+
+
+```````````````````````````````` example
+- [x] * some text
+- [ ] > some text
+- [x]
+  * some text
+- [ ]
+  > some text
+.
+<ul class="task-list">
+<li><input type="checkbox" disabled="" checked="" />* some text</li>
+<li><input type="checkbox" disabled="" />&gt; some text</li>
+<li><input type="checkbox" disabled="" checked="" /><ul>
+<li>some text</li>
+</ul></li>
+<li><input type="checkbox" disabled="" /><blockquote>
+<p>some text</p>
+</blockquote></li>
+</ul>
+````````````````````````````````


### PR DESCRIPTION
Some of these are the same fixes as https://github.com/pulldown-cmark/pulldown-cmark/pull/1017 (except the indentation bug in commonmark-hs, and the lone marker bug in pulldown-cmark)