### PR TITLE
math: do not allow closer followed by digit

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/Math.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/Math.hs
@@ -4,7 +4,7 @@ module Commonmark.Extensions.Math
   ( HasMath(..)
   , mathSpec )
 where
-import Control.Monad (mzero)
+import Control.Monad (guard, mzero)
 import Commonmark.Types
 import Commonmark.Tokens
 import Commonmark.Syntax
@@ -15,6 +15,7 @@ import Commonmark.Html
 import Text.Parsec
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Char (isDigit)
 
 mathSpec :: (Monad m, IsBlock il bl, IsInline il, HasMath il)
          => SyntaxSpec m il bl
@@ -44,10 +45,15 @@ parseMath = try $ do
   let isWs c = c == ' ' || c == '\t' || c == '\r' || c == '\n'
   if display
      then displayMath contents <$ symbol '$'
-     else if T.null contents || isWs (T.last contents)
-             -- don't allow math to end with SPACE + $
-             then mzero
-             else return $ inlineMath contents
+     else do
+             -- don't allow empty inline math
+             guard $ not $ T.null contents
+             -- don't allow inline math to end with SPACE + $
+             guard $ not $ isWs $ T.last contents
+             -- don't allow the closer followed by numbers ($5)
+             let startsWithDigit = maybe False (isDigit . fst) . T.uncons
+             notFollowedBy $ satisfyWord startsWithDigit
+             pure $ inlineMath contents
 
 -- Int is number of embedded groupings
 pDollarsMath :: Monad m => Int -> InlineParser m [Tok]

--- a/commonmark-extensions/test/math.md
+++ b/commonmark-extensions/test/math.md
@@ -87,3 +87,27 @@ $b<a>c$
 .
 <p><span class="math inline">\(b&lt;a&gt;c\)</span></p>
 ````````````````````````````````
+
+The inline math closer cannot be immediately followed by a digit.
+The opener can be, though.
+Display math isn't subject to this rule.
+```````````````````````````````` example
+$1$2$3
+
+$1$2$3$
+
+$1{$2$}3$
+
+$$1$$2$$3
+
+$$1$$2$$3$$
+
+$$1{$$2$$}3$$
+.
+<p>$1$2$3</p>
+<p>$1$2<span class="math inline">\(3\)</span></p>
+<p><span class="math inline">\(1{$2$}3\)</span></p>
+<p><span class="math display">\[1\]</span>2$$3</p>
+<p><span class="math display">\[1\]</span>2<span class="math display">\[3\]</span></p>
+<p><span class="math display">\[1{$$2$$}3\]</span></p>
+````````````````````````````````


### PR DESCRIPTION
Fixes #167
    
With this change, closing `$` cannot be followed by a decimal digit. For example, `$1$` is fine, but `$1$2` is not.
    
The rule added here is supposed to be the same as Pandoc's CommonMark or Comrak, and it shouldn't hurt any important cases.