### PR TITLE
Prevent quadratic parsing on math spans

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/Math.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/Math.hs
@@ -16,6 +16,7 @@ import Text.Parsec
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Char (isDigit)
+import Data.Word (Word16)
 
 mathSpec :: (Monad m, IsBlock il bl, IsInline il, HasMath il)
          => SyntaxSpec m il bl
@@ -55,8 +56,10 @@ parseMath = try $ do
              notFollowedBy $ satisfyWord startsWithDigit
              pure $ inlineMath contents
 
--- Int is number of embedded groupings
-pDollarsMath :: Monad m => Int -> InlineParser m [Tok]
+-- Word16 is number of embedded groupings
+-- We want wrapping semantics because that limits the amount of backtracking
+-- from adversarial input.
+pDollarsMath :: Monad m => Word16 -> InlineParser m [Tok]
 pDollarsMath n = do
   tk@(Tok toktype _ _) <- anyTok
   case toktype of

--- a/commonmark-extensions/test/math.md
+++ b/commonmark-extensions/test/math.md
@@ -61,6 +61,8 @@ And this is inline math:
 <span class="math inline">\(\text{Hello $x$ there!}\)</span></p>
 ````````````````````````````````
 
+The results become inaccurate at over 65,536 levels of nesting.
+
 
 To avoid treating currency signs as math delimiters,
 one may occasionally have to backslash-escape them:
@@ -75,9 +77,9 @@ Dollar signs must also be backslash-escaped if they
 occur within math:
 
 ```````````````````````````````` example
-$\text{\$}$
+$foo\$bar$
 .
-<p><span class="math inline">\(\text{\$}\)</span></p>
+<p><span class="math inline">\(foo\$bar\)</span></p>
 ````````````````````````````````
 
 Everthing inside the math construction is treated


### PR DESCRIPTION
Before
------

    % python3 -c 'N=10000; print("${" * N)' | time commonmark --extension=math > /dev/null
    commonmark --extension=math > /dev/null  3.24s user 0.02s system 99% cpu 3.294 total
    % python3 -c 'N=100000; print("${" * N)' | time commonmark --extension=math > /dev/null
    commonmark --extension=math > /dev/null  893.99s user 5.64s system 99% cpu 14:59.78 total

After
-----

    % python3 -c 'N=10000; print("${" * N)' | time commonmark --extension=math > /dev/null
    commonmark --extension=math > /dev/null  3.61s user 0.03s system 98% cpu 3.680 total
    % python3 -c 'N=100000; print("${" * N)' | time commonmark --extension=math > /dev/null
    commonmark --extension=math > /dev/null  83.97s user 0.31s system 100% cpu 1:24.19 total

Description
-----------

A finite, wrapping integer is deliberately used here because that means it can't be forced to backtrack >= $2^{16}$ times.

To convince yourself of this, imagine a paragraph with $2^{16}$ dollar signs it it, none of which are potential closers for the other and none of which are escaped (so `parseMath` will attempt to parse them and fail), and imagine trying to add another dollar sign that won't be recognized as a potential closer for any of them. What will the first run of `pDollarsMath` see when it starts at the first one?

When `pDollarsMath` scans for a closing dollar sign to match the opening dollar sign, $n$ is going to have some value other than zero. Let's say, for the first candidate, it's 1:

    ${$
    ^ - second dollar sign: n = 1
    |
    - first dollar sign

Will any following dollar sign ever have $n = 1$? For that to happen, the braces between them have to "match sum" up to $0 \mod 2^{16}$, either because they're balanced or because they wrap around:

    ${${}$ - third dollar sign: also n = 1
    ^ - second dollar sign: n = 1
    |
    - first dollar sign

That means the first dollar sign won't recognize the second or third dollars sign as a potential closer, but it means the second dollar sign will see the third, which we're trying to avoid!

This means, if none of the dollar signs are potential closers, then every one of them must have a different value for $n$ when parsing as potential closers after the first dollar sign. And since there's $2^{16}-1$ of them, that means every value for $n$ other than 0 has been taken, and it is impossible to add another dollar sign to the paragraph without it matching *something*.

If I was a better writer, this explanation would be shorter.