### PR TITLE
FIX: handle empty task list items correctly

### DIFF
--- a/commonmark-extensions/src/Commonmark/Extensions/TaskList.hs
+++ b/commonmark-extensions/src/Commonmark/Extensions/TaskList.hs
@@ -133,7 +133,8 @@ taskListItemBlockSpec = BlockSpec
                                listItemType lidata
                     -> addNodeToStack linode
                   _ -> addNodeToStack listnode >> addNodeToStack linode
-             blankAfterMarker <- optionMaybe blankLine
+             blankAfterMarker <- optionMaybe $
+               try (blankLine <* lookAhead blankLine) <|> lookAhead blankLine
              pos' <- getPosition
              case blankAfterMarker of
                   Just _ -> return ()
@@ -153,10 +154,11 @@ taskListItemBlockSpec = BlockSpec
                              (ListItemData (BulletList '*') False 0
                               False False)
              -- a marker followed by two blanks is just an empty item:
-             guard $ null (blockBlanks ndata) ||
-                     not (null children)
              pos <- getPosition
-             gobbleSpaces (listItemIndent lidata) <|> 0 <$ lookAhead blankLine
+             case blockBlanks ndata of
+                  _:_ | null children -> lookAhead blankLine
+                  _ -> () <$ gobbleSpaces (listItemIndent lidata)
+                       <|> lookAhead blankLine
              return $! (pos, node)
      , blockConstructor    = fmap mconcat . renderChildren
      , blockFinalize       = \(Node cdata children) parent -> do

--- a/commonmark-extensions/test/task_lists.md
+++ b/commonmark-extensions/test/task_lists.md
@@ -91,3 +91,13 @@ There is no empty paragraph after the `]`.
 </li>
 </ul>
 ````````````````````````````````
+
+```````````````````````````````` example
+- [ ]
+- [ ] b
+.
+<ul class="task-list">
+<li><input type="checkbox" disabled="" /></li>
+<li><input type="checkbox" disabled="" />b</li>
+</ul>
+````````````````````````````````


### PR DESCRIPTION
This change preserves the blank line after an empty task marker unless it is
followed by another blank line, and aligns task list item continuation with the
core list continuation logic so that empty items terminate correctly.

## Changes
- Preserve a single blank line after an empty task marker using `lookAhead`
- Only consume a blank line immediately when followed by another blank line
- Restrict continuation of empty task list items to blank lines only
- Prevent subsequent sibling task list items from being parsed as nested children

Fixes #174